### PR TITLE
(#6) .travis.yml bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-sudo: required
-services:
-- docker
+sudo: false
 language: java
 cache:
   directories:
@@ -18,22 +16,22 @@ jobs:
   - if: type = push AND tag IS present
     script:
     - mvn -P site clean compile site
-    deploy:
-      provider: pages
-      skip_cleanup: true
-      local_dir: target/site/
-      github_token: "$site_token"
-      on:
-        tags: true
-        branch: master
-    deploy:
-      provider: releases
-      api_key: "$site_token"
-      file: LATEST_RELEASE.md
-      skip_cleanup: true
-      on:
-        tags: true
-        branch: master
+    - deploy:
+        provider: pages
+        skip_cleanup: true
+        local_dir: target/site/
+        github_token: "$site_token"
+        on:
+          tags: true
+          branch: master
+    - deploy:
+        provider: releases
+        api_key: "$site_token"
+        file: RELEASE.md
+        skip_cleanup: true
+        on:
+          tags: true
+          branch: master
 env:
   global:
     secure: equ1pMFdH8UvezLBV18qrxv1csC+jCCa7gyUKIYh4unWos/MzVaINCoUsg/UHGo+ag7s77EyyYN0XYAqMx5fuauxVALGfrm1m0hMbRpoMVoDaDxaR1sFY3mqV2s1BkFWxPwB51/9vvSzhtq3eHnheFQEwM6mJsZQq6/L7wX9fnnJpwGbqG4vBu6SsqSdkJzsN/2WnG+EXTdOnyzDoWFWBHu/QIcmW4MC8+41TdT1YGWRnMn0nFZMWpVwSn4douNr+T2RI1u/ER/ZHgAiPn+skOmP9NObQDWkXo0kxNNtK82gbPGFrXqv7UuaWh7Zb+OGfK0E9HdTV+keBOdyNHZcTfRihBkfy/ubnEUDy6xxKZ0W/biXPmP3gkdDVhbW3O2QsD/Whfps8FM2F+nZrOadDofZztP9rHxRTcxNwQAOBlbGk9TrU4OtBdTFnyXByVL9J7yJu1N1OujHYb/wDTKy8UrEC+KrM5asrBukMKE+B0y/oIAq3JgLyNhMMXfa9EayiSMbLdymKlXSqviNYkLXrLNCGI779ySSKJHNxTnXRF0ltOuwc3Bw4Fi0Oy89smOsx76+mZLcWQ/6sSX4CK6XnWO5KcgKWj/VSfo1M6Jq+jDpDFwe5hJorMZ0kCH820Ooytc05rVYGHW6/epx8P+N6dARpZ6g7I5drbzCKjvBol4=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
-## Latest release
-For the latest release only, see [latest release](./LATEST_RELEASE.md).
+**Latest release**
+For the latest release only, see [latest release](./RELEASE.md).
 
-## CHANGELOG
-v0.1.0:
+# CHANGELOG
+## 0.1.1:
+
+**Features:**
+
+**Bugs:**
+* (#6) .travis.yml bugs
+
+## 0.1.0:
 
 **Features:**
 * (#2) Setup project skeleton

--- a/LATEST_RELEASE.md
+++ b/LATEST_RELEASE.md
@@ -1,8 +1,0 @@
-v0.1.0:
-
-**Features:**
-* (#2) Setup project skeleton
-* (#4) Github releases from Travis
-
-**Bugs:**
-

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+0.1.1:
+
+**Features:**
+
+**Bugs:**
+* (#6) .travis.yml bugs


### PR DESCRIPTION
    (FIX) .travis.yml: removed sudo and service requirements
    (FIX) .travis.yml: fixed syntax issues
    (REF) LATEST_RELEASE.md -> RELEASE.md
          It is not possible to specify release notes from travis,
          see https://github.com/travis-ci/travis-ci/issues/6423

closes #6 